### PR TITLE
Use dynamic base path for Vite dev vs. GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  base: "/BreathLab/",
+// Use a different base path when serving locally vs. building for GitHub Pages.
+// The dev server runs at the root URL, while production builds are served
+// from the /BreathLab/ subdirectory on GitHub Pages.
+export default defineConfig(({ command }) => ({
+  base: command === "build" ? "/BreathLab/" : "/",
   plugins: [react()],
-});
+}));


### PR DESCRIPTION
## Summary
- Serve app from root during `npm run dev`
- Keep `/BreathLab/` base for production builds on GitHub Pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce2df118883319a74fd86adc63b1a