### PR TITLE
Use dynamic base path for Vite dev vs. GitHub Pages

### DIFF
--- a/src/BreathLab.jsx
+++ b/src/BreathLab.jsx
@@ -20,7 +20,7 @@ export default function BreathLab() {
     return () => window.removeEventListener("resize", onR);
   }, []);
 
-  const RAW_SVG = "/lungs-lung-svgrepo-com.svg";
+  const RAW_SVG = import.meta.env.BASE_URL + "lungs-lung-svgrepo-com.svg";
 
   const [lungPaths, setLungPaths] = useState(null);
   useEffect(() => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  base: "/BreathLab/",
+// Use a different base path when serving locally vs. building for GitHub Pages.
+// The dev server runs at the root URL, while production builds are served
+// from the /BreathLab/ subdirectory on GitHub Pages.
+export default defineConfig(({ command }) => ({
+  base: command === "build" ? "/BreathLab/" : "/",
   plugins: [react()],
-});
+}));


### PR DESCRIPTION
## Summary
- Serve app from root during `npm run dev`
- Keep `/BreathLab/` base for production builds on GitHub Pages
- Resolve public SVG path using `import.meta.env.BASE_URL` so assets load when hosted

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce2df118883319a74fd86adc63b1a